### PR TITLE
Root Password can now be set

### DIFF
--- a/rcbops_allinone_inone.template
+++ b/rcbops_allinone_inone.template
@@ -468,11 +468,11 @@ resources:
             # Exit Zero
             exit 0
           params:
-            %cookbook_version%: { get_param: cookbook_version }
-            %chef_admin_pass%: { get_param: chef_admin_pass }
-            %os_admin_pass%: { get_param: os_admin_pass }
-            %rabbit_pass%: { get_param: rabbit_pass }
-            %system_pass%: { get_param: system_pass }
+            "%cookbook_version%": { get_param: cookbook_version }
+            "%chef_admin_pass%": { get_param: chef_admin_pass }
+            "%os_admin_pass%": { get_param: os_admin_pass }
+            "%rabbit_pass%": { get_param: rabbit_pass }
+            "%system_pass%": { get_param: system_pass }
 
 outputs:
 


### PR DESCRIPTION
Updated template such that the system users password is now set at the end of the installation run.The system user's password (root) is now defined in the template.

This change will allow the user easier access to the shell of the Openstack Node.

I also flip-flopped the chef/nova pw's as they were in the wrong places.
