### PR TITLE
Updated all in one Rackspace Private Cloud Installation

### DIFF
--- a/dev/rcbops_allinone_inone.template
+++ b/dev/rcbops_allinone_inone.template
@@ -146,10 +146,10 @@ resources:
 
             # Setup passwords
             
-            CHEF_PW="%chef_admin_pass%"
-            RMQ_PW="%rabbit_pass%"
-            NOVA_PW="%os_admin_pass%"
-            SYSTEM_PW="%system_pass%"
+            export CHEF_PW="%chef_admin_pass%"
+            export RMQ_PW="%rabbit_pass%"
+            export NOVA_PW="%os_admin_pass%"
+            export SYSTEM_PW="%system_pass%"
 
             # Set an override for my roles
             export RUN_LIST="%run_list%"

--- a/prod/rcbops_allinone_inone.template
+++ b/prod/rcbops_allinone_inone.template
@@ -146,10 +146,10 @@ resources:
 
             # Setup passwords
             
-            CHEF_PW="%chef_admin_pass%"
-            RMQ_PW="%rabbit_pass%"
-            NOVA_PW="%os_admin_pass%"
-            SYSTEM_PW="%system_pass%"
+            export CHEF_PW="%chef_admin_pass%"
+            export RMQ_PW="%rabbit_pass%"
+            export NOVA_PW="%os_admin_pass%"
+            export SYSTEM_PW="%system_pass%"
 
             # Set an override for my roles
             export RUN_LIST="%run_list%"

--- a/qa/rcbops_allinone_inone.template
+++ b/qa/rcbops_allinone_inone.template
@@ -146,10 +146,10 @@ resources:
 
             # Setup passwords
             
-            CHEF_PW="%chef_admin_pass%"
-            RMQ_PW="%rabbit_pass%"
-            NOVA_PW="%os_admin_pass%"
-            SYSTEM_PW="%system_pass%"
+            export CHEF_PW="%chef_admin_pass%"
+            export RMQ_PW="%rabbit_pass%"
+            export NOVA_PW="%os_admin_pass%"
+            export SYSTEM_PW="%system_pass%"
 
             # Set an override for my roles
             export RUN_LIST="%run_list%"

--- a/staging/rcbops_allinone_inone.template
+++ b/staging/rcbops_allinone_inone.template
@@ -146,10 +146,10 @@ resources:
 
             # Setup passwords
             
-            CHEF_PW="%chef_admin_pass%"
-            RMQ_PW="%rabbit_pass%"
-            NOVA_PW="%os_admin_pass%"
-            SYSTEM_PW="%system_pass%"
+            export CHEF_PW="%chef_admin_pass%"
+            export RMQ_PW="%rabbit_pass%"
+            export NOVA_PW="%os_admin_pass%"
+            export SYSTEM_PW="%system_pass%"
 
             # Set an override for my roles
             export RUN_LIST="%run_list%"


### PR DESCRIPTION
This update makes it possible to deploy the rackspace Private Cloud using 
in a more consumable fashion. Here are the highlights 

Overview:
- Now supports RHEL/Ubuntu/CentOS
- Now has the ability to change the default run lists
- Now allows the user to for the script and repoint it to a different script if they so choose
- Installation template is now a lot smaller as the script with the meat of the install is an external resource.

New abilities in Script: 
- The new installer now has better support for gauging system resources. This is required because new cloud server images do not come with a swap partition and when a user is running everything in one server the likelihood the system will swap is high.
- Dependencies in the script are better resolved
- MOTD is now set with information on post build / deployment which also effects the main login page even in console.
