### PR TITLE
Add bfv server to template

### DIFF
--- a/dev/rackconnect.yaml
+++ b/dev/rackconnect.yaml
@@ -26,8 +26,8 @@ parameters:
 
 resources:
 
- # Attaches the server to the configured Rackconnect
- # load balancer pool
+  # Attaches the server to the configured Rackconnect
+  # load balancer pool
   pool_node:
     type: Rackspace::RackConnect::PoolNode
     properties:
@@ -40,6 +40,20 @@ resources:
     type: Rackspace::RackConnect::PublicIP
     properties:
       server_id: { get_resource: server }
+
+  # Test with a Boot From Volume server
+  bfv_pool_node:
+     type: Rackspace::RackConnect::PoolNode
+     properties:
+       server_id: { get_resource: bfv_server }
+       pool: { get_param: rcpool }
+
+
+  # Attaches a Rackconnected public ip to the server
+  bfv_public_ip:
+     type: Rackspace::RackConnect::PublicIP
+     properties:
+       server_id: { get_resource: bfv_server }
 
   # Cloud server attached to a Rackconnect network
   server:
@@ -60,3 +74,37 @@ resources:
       metadata:
         rax-heat: { get_param: "OS::stack_id" }
         stack-name: { get_param: "OS::stack_name" }
+
+  # Boot from volume server.
+  # Code contributed by: @ryan-walker
+  bfv_server:
+    type: OS::Nova::Server
+    properties:
+      block_device_mapping:
+        - volume_id: {get_resource: volume}
+          device_name: vda
+          delete_on_termination: true
+      user_data_format: RAW
+      # config_drive: "true"
+      flavor: 3.75 GB Compute v1
+      name:
+        str_replace:
+          template: stack-server
+          params:
+            stack: { get_param: "OS::stack_name" }
+      networks:
+      # Can only assign the server to a Rackconnect network
+      # and optionally ServiceNet. Cannot assign to the
+      # PublicNet
+      - uuid: { get_param: rcnet }
+      - uuid: "11111111-1111-1111-1111-111111111111"
+      metadata:
+        rax-heat: { get_param: "OS::stack_id" }
+        stack-name: { get_param: "OS::stack_name" }
+
+  volume:
+    type: OS::Cinder::Volume
+    properties:
+      size: 50
+      volume_type: SSD
+      image: 749dc22a-9563-4628-b0d1-f84ced8c7b7a


### PR DESCRIPTION
Add a boot from volume server to the rackconnect sample template.